### PR TITLE
Add support for ONT SQK-RBK114-96 kit barcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4](https://github.com/CFIA-NCFAD/miso-tool/releases/tag/0.0.4) - 2023-12-18
+
+Added support for SQK-RBK114-96, which has the same barcode sequences as SQK-RBK110-96.
+
 ## [0.0.3](https://github.com/CFIA-NCFAD/miso-tool/releases/tag/0.0.3) - 2023-11-15
 
 Add Rich as dependency since it's not automatically installed with Typer.

--- a/src/miso_tool/__about__.py
+++ b/src/miso_tool/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Peter Kruczkiewicz <peter.kruczkiewicz@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/src/miso_tool/samples.py
+++ b/src/miso_tool/samples.py
@@ -205,10 +205,10 @@ def get_sample_barcode(sampleid: str, run: dict) -> Tuple[Optional[str], Optiona
                     return None, None
                 barcode_two = sample.get("barcode_two", None)
                 seqkit = run.get("sequencingKit", None)
-                if seqkit and seqkit == "SQK-RBK110-96":
+                if seqkit is not None and seqkit in ("SQK-RBK110-96", "SQK-RBK114-96"):
                     barcode = get_rbk11096_barcode(barcode)
                     if barcode is None:
-                        error_msg = f"Could not find RBK110-96 barcode for {sampleid} in run {run['name']}"
+                        error_msg = f"Could not find RBK110-96/RBK114-96 barcode for {sampleid} in run {run['name']}"
                         raise ValueError(error_msg)
                     return barcode, None
                 else:


### PR DESCRIPTION
SQK-RBK110-96 and SQK-RBK114-96 barcodes are the same. This PR adds support for SQK-RBK114-96.