### PR TITLE
Add support for new Illumina MiSeq Control Software FASTQ save destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5](https://github.com/CFIA-NCFAD/miso-tool/releases/tag/0.0.5) - 2023-12-
+
+Illumina MiSeq with MiSeq Control Software v4.0.0 outputs FASTQ files to a different destination. This version of miso-tool adds support for this new destination.
+
 ## [0.0.4](https://github.com/CFIA-NCFAD/miso-tool/releases/tag/0.0.4) - 2023-12-18
 
 Added support for SQK-RBK114-96, which has the same barcode sequences as SQK-RBK110-96.

--- a/src/miso_tool/__about__.py
+++ b/src/miso_tool/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Peter Kruczkiewicz <peter.kruczkiewicz@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/src/miso_tool/illumina.py
+++ b/src/miso_tool/illumina.py
@@ -2,6 +2,7 @@ import logging
 import re
 from collections import defaultdict
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from tqdm import tqdm
@@ -12,7 +13,7 @@ illumina_read_regex = re.compile(r"^([\w\-\_]+)_S\d+_L\d+_R[12]_001\.fastq\.gz$"
 logger = logging.getLogger(__name__)
 
 
-def get_illumina_samplesheet_path(illumina_run_path: Path) -> Path | None:
+def get_illumina_samplesheet_path(illumina_run_path: Path) -> Optional[Path]:
     sample_sheet_path = illumina_run_path / "Data/Intensities/BaseCalls/SampleSheet.csv"
     if sample_sheet_path.exists():
         return sample_sheet_path
@@ -39,6 +40,9 @@ def link_sample_ids_to_reads(
     for run_name, run_path in tqdm(illumina_runs, desc="Processing Illumina runs"):
         try:
             ss = get_illumina_samplesheet_path(run_path)
+            if ss is None:
+                logger.warning(f"No samplesheet found for run '{run_name}' at '{run_path}'")
+                continue
             df_illumina_ss = read_illumina_samplesheet(ss)
             illumina_run_to_samplesheet[run_name] = df_illumina_ss
             id_to_path = defaultdict(list)
@@ -112,6 +116,9 @@ def to_illumina_nextflow_df(illumina_sample_run_infos: list[dict]) -> tuple[pd.D
     logger.info(f"Checking that all {len(runs)} Illumina runs have a SampleSheet.csv file that can be read.")
     for run_name, run_path in tqdm(runs, desc="Checking Illumina runs"):
         ss = get_illumina_samplesheet_path(run_path)
+        if ss is None:
+            logger.warning(f"No samplesheet found for run '{run_name}' at '{run_path}'")
+            continue
         if not ss.exists() or not ss.is_file() or not ss.stat().st_size > 0:
             error_msg = f"Could not find samplesheet.csv for {run_name} at '{ss}'"
             raise FileNotFoundError(error_msg)

--- a/src/miso_tool/illumina.py
+++ b/src/miso_tool/illumina.py
@@ -12,8 +12,13 @@ illumina_read_regex = re.compile(r"^([\w\-\_]+)_S\d+_L\d+_R[12]_001\.fastq\.gz$"
 logger = logging.getLogger(__name__)
 
 
-def get_illumina_samplesheet_path(illumina_run_path: Path) -> Path:
-    return illumina_run_path / "Data/Intensities/BaseCalls/SampleSheet.csv"
+def get_illumina_samplesheet_path(illumina_run_path: Path) -> Path | None:
+    sample_sheet_path = illumina_run_path / "Data/Intensities/BaseCalls/SampleSheet.csv"
+    if sample_sheet_path.exists():
+        return sample_sheet_path
+    for path in illumina_run_path.rglob("SampleSheetUsed.csv"):
+        return path
+    return None
 
 
 def read_illumina_samplesheet(path: Path) -> pd.DataFrame:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -6,7 +6,7 @@ def test_fix_lsts_sample_name():
         ("WIN-AH-2021-OTH-1-1", "WIN-AH-2021-OTH-0001-1"),
         ("WIN-AH-2021-OTH-123-1-1", "WIN-AH-2021-OTH-0123-1-1"),
         ("WIN-AH-2021-OTH-0023-a bunch of words", "WIN-AH-2021-OTH-0023-a-bunch-of-words"),
-        ("2021-OTH-1-(shh) - it\'s a secret!", "WIN-AH-2021-OTH-0001-shh-it-s-a-secret"),
+        ("2021-OTH-1-(shh) - it's a secret!", "WIN-AH-2021-OTH-0001-shh-it-s-a-secret"),
         ("2021-OTH-1-1", "WIN-AH-2021-OTH-0001-1"),
         ("nothing wrong here", "nothing-wrong-here"),
         ("another #$%^&*()+sample", "another-sample"),


### PR DESCRIPTION
Illumina MiSeq with MiSeq Control Software v4.0.0 outputs FASTQ files to a different destination. This PR adds support for this new destination.

* illumina.py: Look for SampleSheetUsed.csv if SampleSheet.csv not found in legacy location